### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/graphite_aclproxy/proxy.py
+++ b/graphite_aclproxy/proxy.py
@@ -39,7 +39,7 @@ configfile_name = 'graphite_aclproxy.conf'
 
 instance_relative_config = False
 instance_path = None
-if os.path.exists('/etc/carbon/%s' %(configfile_name, )):
+if os.path.exists('/etc/carbon/{0!s}'.format(configfile_name )):
     instance_relative_config = True
     instance_path = '/etc/carbon'
     
@@ -89,7 +89,7 @@ def favicon():
 @app.route('/', defaults={'url': ''})
 @app.route('/<path:url>')
 def root(url):
-    LOG.warn('Unknown url: %s' %(url,))
+    LOG.warn('Unknown url: {0!s}'.format(url))
     abort(404)
  
  
@@ -108,7 +108,7 @@ def proxy():
  
 def upstream_req(args):
 
-    url = '%s/render/' % (app.config['REQUESTS_GRAPHITE_URL'],)
+    url = '{0!s}/render/'.format(app.config['REQUESTS_GRAPHITE_URL'])
     headers = {}
     r=requests.get(url, stream=True , params = args, headers=headers, verify=app.config['REQUESTS_SSL_VERIFY'])
     LOG.info("UpstreamRequest: '%s','%s'", r.status_code, args)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bzed:graphite_aclproxy?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bzed:graphite_aclproxy?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
